### PR TITLE
Precedence of transpose operation corrected and string assignment added

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -12,6 +12,7 @@ class Mparser(Parser):
         ("nonassoc", '<', '>', 'LE', 'GE', 'EQ', 'NEQ'),
         ("left", '+', '-', 'DOTADD', 'DOTSUB'),
         ("left", '*', '/', 'DOTMUL', 'DOTDIV'),
+        ("right", "\'"),
         ("right", 'UMINUS'),
     )
 
@@ -44,12 +45,13 @@ class Mparser(Parser):
     # ---------- ASSIGNMENT -----------
     #
     @_('ref "="       expr ";"',
+       'ref "="     STRING ";"',
        'ref ADDASSIGN expr ";"',
        'ref SUBASSIGN expr ";"',
        'ref MULASSIGN expr ";"',
        'ref DIVASSIGN expr ";"')
     def assignment(self, p):
-        return (p[1], p.ref, p.expr)
+        return (p[1], p.ref, p[2])
 
     @_('ID')
     def ref(self, p):


### PR DESCRIPTION
Znalazłem dwie pierdoły, które poprawiłem.
1. Zgodnie z przykładem opisanym w example.txt transpozycja macierzy ma być wykonywana przed operacjami arytmetycznymi na macierzach (transpozycja macierzy miała za niski priorytet)
2. Parser nie akceptował przypisania STRING do zmiennej (dla example_full.txt rzucało błędem)

A tak to klasa gramatyka <3